### PR TITLE
Added deferred.

### DIFF
--- a/deferred/README.md
+++ b/deferred/README.md
@@ -1,0 +1,66 @@
+# Deferred Actions
+There are times where a user may want to schedule a command or update to be sent to an Item after a given period of time.
+This library handles the creation and management of the timers.
+
+# Dependencies
+- time_utils used to parse various forms of time durations into something that can be used to schedule a Timer
+- timerMgr used to manage the Timers
+
+# Purpose
+Simplifies the use case where command or update should be scheduled to be sent at sometime in the future.
+Creating a Timer for this is possible but this library deals with all that book keeping and management of the Timers.
+The delay can be defined using a parsed duration string of the format "xd xh xm xs" (see parse_duration) or a DateTime.
+
+# How it works
+Import and call the `deferred` function and, if required, the `cancel` and `cancel_all` functions.
+
+## deferred
+This is the function that will be used the most.
+
+```python
+deferred(target, value, "5m", log, is_command=True)
+```
+
+Argument | Purpose
+-|-
+`target` | The name of the Item
+`value` | The state or the command to send
+`when` | The time to issue the command or state. See `to_datetime` in time_utils for details
+`log` |logger
+`is_command` | Indicates whether to send a command or post update
+
+
+## cancel
+Cancels the Timer for the given Item.
+
+```python
+cancel("Name")
+```
+
+## cancel_all
+Cancels all the existing Timers.
+
+```python
+cancel_all()
+```
+
+# Examples
+
+```python
+from community.timer_mgr import deferred, cancel, cancel_all
+
+
+...
+
+    # In a Rule, send a command to Foo in 5 minutes
+    deferred("Foo", "ON", "5m", log)
+
+    # In a Rule, send a n update to Foo in 5 minutes using DateTime
+    deferred("Foo", "OFF", DateTime().now().plusMinutes(5), log, is_command=False)
+
+    # Cancel the deffered action for Foo
+    cancel("Foo")
+
+    # Cancel all the deferred actions
+    cancel_all()
+```

--- a/deferred/automation/lib/python/community/deferred.py
+++ b/deferred/automation/lib/python/community/deferred.py
@@ -1,0 +1,82 @@
+"""
+Copyright June 25, 2020 Richard Koshak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from core.actions import ScriptExecution
+from core.jsr223.scope import events
+from org.joda.time import DateTime
+import community.time_utils
+reload(community.time_utils)
+from community.time_utils import to_datetime
+import community.timer_mgr
+reload(community.timer_mgr)
+from community.timer_mgr import TimerMgr
+
+timers = TimerMgr()
+
+def timer_body(target, value, is_command, log):
+    """
+    Called when the differed action timer expires, sends the command to the
+    target Item.
+    Arguments:
+        - target: Item name to send the command to
+        - value: Command or state to issue to the target Item
+        - is_command: Whether to send value to target as a command or an update
+        - log: logger passed in from the Rule that is using this.
+    """
+    log.info("Executing deferred action {} against {}".format(value, target))
+    if is_command:
+        events.sendCommand(target, value)
+    else:
+        events.postUpdate(target, value)
+
+def deferred(target, value, when, log, is_command=True, dt=None, delay=None):
+    """
+    Use this function to schedule a command to be sent to an Item at the
+    specified time or after the speficied delay. If the passed in time or delay
+    ends up in the past, the command is sent immediately.
+    Arguments:
+        - target: Item name to send the command to
+        - value: the command to send the Item
+        - when: at what time to delay to action until, see to_datetime in the timer_utils library
+        - is_command: whether to send value to target as an update or command,
+        defaults to True
+        - log: logger passed in from the Rule
+    """
+
+    trigger_time = to_datetime(when, log)
+
+    # If trigger_time is in the past, schedule for now
+    if trigger_time.isBefore(DateTime.now()):
+        trigger_time = DateTime.now()
+
+    # Schedule the timer
+    func = lambda: timer_body(target, value, is_command, log)
+    flap = lambda: log.info("there is already a timer set for {}, rescheduling"
+                            .format(target))
+    timers.check(target, trigger_time, function=func, flapping_function=flap, reschedule=True)
+
+def cancel(target):
+    """
+    Cancels the timer associated with target if it exists.
+    Arguments:
+        - target: the Item name whose timer is to be cancelled
+    """
+    timers.cancel(target)
+
+def cancel_all():
+    """
+    Cancels all timers.
+    """
+    timers.cancel_all()

--- a/deferred/test/deferred-tests.py
+++ b/deferred/test/deferred-tests.py
@@ -1,0 +1,68 @@
+import community.deferred
+reload(community.deferred)
+from community.deferred import deferred, cancel_all, cancel
+from core.log import log_traceback, logging, LOG_PREFIX
+from org.joda.time import DateTime
+import time
+
+log = logging.getLogger("{}.TEST.deferred".format(LOG_PREFIX))
+
+log.info("Starting deferred tests")
+
+# Create an Item to test with
+log.info("Creating test Item Deferred_Test")
+from core.items import add_item
+item = "Deferred_Test"
+add_item(item, item_type="Switch")
+
+try:
+    events.postUpdate(item, "OFF")
+    time.sleep(0.1)
+    assert items[item] == OFF, "Item didn't initialize to OFF"
+
+    # Schedule based on DT
+    t = DateTime.now().plusSeconds(1)
+    deferred(item, "ON", t, log)
+    time.sleep(1.1)
+    assert items[item] == ON, "Item didn't go to ON after a second with specific time"
+
+    # Schedule based on duration
+    deferred(item, "OFF", "1s", log)
+    time.sleep(1.1)
+    assert items[item] == OFF, "Item didn't go to OFF after a second with duration"
+
+    # Reschedule
+    deferred(item, "ON", "1s", log)
+    time.sleep(0.1)
+    assert items[item] == OFF, "Item isn't still OFF after initial schedule"
+    deferred(item, "ON", "2s", log)
+    time.sleep(1)
+    assert items[item] == OFF, "Timer didn't get rescheduled!"
+    time.sleep(1.1)
+    assert items[item] == ON, "Timer didn't reschedule on time!"
+
+    # Cancel
+    deferred(item, "OFF", "1s", log)
+    assert items[item] == ON, "Item isn't still ON after last test"
+    cancel(item)
+    time.sleep(1.1)
+    assert items[item] == ON, "Timer didn't cancel!"
+
+    # Cancel All
+    deferred(item, "OFF", "1s", log)
+    cancel_all()
+    time.sleep(1.1)
+    assert items[item] == ON, "Timer didn't cancel all"
+
+except AssertionError:
+    import traceback
+    log.error("Exception: {}".format(traceback.format_exc()))
+except TypeError:
+    import traceback
+    log.error("Exception: {}".format(traceback.format_exc()))
+else:
+    log.info("Deferred tests passed!")
+finally:
+    log.info("Deleting test Item")
+    from core.items import remove_item
+    remove_item(item)


### PR DESCRIPTION
deferred is a library module that allows one to easily schedule a command or update to an Item to occur in the future.
 
Moved parse_duration to time_utils as new functions were added to the library as a result of building deferred. 

Updated timer_mgr to use the new time_utils functions. deferred depends on timer_mgr.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>